### PR TITLE
Zulrah and Vorkath drop table fixes

### DIFF
--- a/src/simulation/monsters/bosses/Vorkath.ts
+++ b/src/simulation/monsters/bosses/Vorkath.ts
@@ -50,6 +50,8 @@ const VorkathTable = new LootTable()
 	/* Other */
 	.add(RareDropTable, undefined, 5)
 	.add(TreeHerbSeedTable, undefined, 3)
+	.add('Snapdragon seed', 1, 1)
+	.add('Torstol seed', 1, 1)
 	.add('Adamantite ore', [10, 30], 7)
 	.add('Coins', [20000, 81000], 5)
 	.add('Grapes', [250, 300], 5)

--- a/src/simulation/monsters/bosses/Zulrah.ts
+++ b/src/simulation/monsters/bosses/Zulrah.ts
@@ -64,7 +64,7 @@ const ZulrahTable = new LootTable()
 	.add('Antidote++(4)', 10, 9)
 	.add('Dragonstone bolt tips', 12, 8)
 	.add('Grapes', 250, 6)
-	.add('Coconut', 20, 5)
+	.add('Coconut', 20, 6)
 	.add('Swamp tar', 1000, 5)
 	.add("Zulrah's scales", 500, 5);
 

--- a/test/DeepMonsters.ts
+++ b/test/DeepMonsters.ts
@@ -87,7 +87,7 @@ test('Zulrah', async (test): Promise<void> => {
 	};
 
 	const Zulrah = Monsters.Zulrah;
-	test.equals(Zulrah.table.totalWeight, 247, 'Zulrah table weight should be 247');
+	test.equals(Zulrah.table.totalWeight, 248, 'Zulrah table weight should be 248');
 
 	const number = 10_000_000;
 	const loot = Monsters.Zulrah.kill(number);
@@ -246,7 +246,7 @@ test('Vorkath', async (test): Promise<void> => {
 	};
 
 	const Vorkath = Monsters.Vorkath;
-	test.equals(Vorkath.table.totalWeight, 148, 'Vorkath table weight should be 148');
+	test.equals(Vorkath.table.totalWeight, 150, 'Vorkath table weight should be 150');
 
 	const number = 10_000_000;
 	const loot = Monsters.Vorkath.kill(number);


### PR DESCRIPTION
Zulrah:
- the weight of the coconut drop is 6, it was wrong on the wiki (wiki is now updated)

Vorkath:
- Snapdragon and torstol seed are both on the main and the rdt table. There is a [note on the wiki](https://oldschool.runescape.wiki/w/Vorkath#cite_note-dd-1)
- the weight of both are 1/150, found by substracting the listed effective drop rate from the rdt drop rate