### PR TITLE
Fixes infernal max cape

### DIFF
--- a/src/structures/Items.ts
+++ b/src/structures/Items.ts
@@ -16,7 +16,7 @@ export interface ItemCollection {
 	[index: string]: Item;
 }
 
-const USELESS_ITEMS = [617, 8890, 6964, 2513, 19492, 11071, 11068];
+const USELESS_ITEMS = [617, 8890, 6964, 2513, 19492, 11071, 11068, 21284];
 
 class Items extends Collection<number, Item | PartialItem> {
 	public async fetchAll(): Promise<void> {


### PR DESCRIPTION
### Description:

-   Infernal max cape have the Duplicate item as the lower ID, so people can't equip it.

### Changes:

-   Added itemID 21284 to the USELESS_ITEMS array.

-   [X] I have tested all my changes thoroughly.
