### PR TITLE
Add two new optional properties to the Item type, custom and icon

### DIFF
--- a/src/meta/types.ts
+++ b/src/meta/types.ts
@@ -232,13 +232,13 @@ export interface Item {
 	 */
 	name: string;
 	/**
-	 * If the item is a members-only.
-	 */
-	members: boolean;
-	/**
 	 * If the item has incomplete wiki data.
 	 */
 	incomplete: boolean;
+	/**
+	 * If the item is a members-only.
+	 */
+	members: boolean;
 	/**
 	 * If the item is tradeable (between players and on the GE).
 	 */
@@ -324,6 +324,10 @@ export interface Item {
 	 */
 	examine: string | null;
 	/**
+	 * Item icon as base64
+	 */
+	icon?: string;
+	/**
 	 * The OSRS Wiki name for the item.
 	 */
 	wiki_name: string | null;
@@ -331,17 +335,12 @@ export interface Item {
 	 * The OSRS Wiki URL (possibly including anchor link).
 	 */
 	wiki_url: string | null;
+	/**
+	 * The OSRS Wiki Exchaange URL (possibly including anchor link).
+	 */
+	wiki_exchange: string | null;
 	equipment: ItemEquipment | null;
 	weapon: ItemWeapon | null;
-	/**
-	 * Special property that will be set to true for custom created items that is used in the bot
-	 * only and have no link with OSRS
-	 */
-	custom?: boolean;
-	/**
-	 * Item icon as base64
-	 */
-	icon?: string;
 }
 
 export interface PartialItem {

--- a/src/meta/types.ts
+++ b/src/meta/types.ts
@@ -333,6 +333,15 @@ export interface Item {
 	wiki_url: string | null;
 	equipment: ItemEquipment | null;
 	weapon: ItemWeapon | null;
+	/**
+	 * Special property that will be set to true for custom created items that is used in the bot
+	 * only and have no link with OSRS
+	 */
+	custom?: boolean;
+	/**
+	 * Item icon as base64
+	 */
+	icon?: string;
 }
 
 export interface PartialItem {

--- a/src/structures/Items.ts
+++ b/src/structures/Items.ts
@@ -24,7 +24,7 @@ class Items extends Collection<number, Item | PartialItem> {
 		).then((res): Promise<any> => res.json());
 
 		for (const item of Object.values(allItems).filter(weirdItemFilter)) {
-			this.set(item.id, item);
+			this.set(item.id, { ...item, custom: false });
 		}
 	}
 
@@ -35,7 +35,7 @@ class Items extends Collection<number, Item | PartialItem> {
 			(res): Promise<any> => res.json()
 		);
 
-		this.set(item.id, item);
+		this.set(item.id, { ...item, custom: false });
 		return item;
 	}
 

--- a/src/structures/Items.ts
+++ b/src/structures/Items.ts
@@ -24,7 +24,7 @@ class Items extends Collection<number, Item | PartialItem> {
 		).then((res): Promise<any> => res.json());
 
 		for (const item of Object.values(allItems).filter(weirdItemFilter)) {
-			this.set(item.id, { ...item, custom: false });
+			this.set(item.id, item);
 		}
 	}
 
@@ -35,7 +35,7 @@ class Items extends Collection<number, Item | PartialItem> {
 			(res): Promise<any> => res.json()
 		);
 
-		this.set(item.id, { ...item, custom: false });
+		this.set(item.id, item);
 		return item;
 	}
 


### PR DESCRIPTION
### Description:

-   Icon was already being set by item fetch, it was just missing on the item Type
-   Add a new property, `custom`, that will be automatically set when custom items are created.

### Changes:

-   Add property `custom?: boolean;`
-   Add property `icon?: string;`

-   [X] I have tested all my changes thoroughly.
