### PR TITLE
Dont treat itemID 0 as undefined anymore

### DIFF
--- a/src/structures/Items.ts
+++ b/src/structures/Items.ts
@@ -41,7 +41,7 @@ class Items extends Collection<number, Item | PartialItem> {
 
 	public get(item: ItemResolvable): Item | PartialItem | undefined {
 		const id = this.resolveID(item);
-		if (!id && id !== 0) return undefined;
+		if (typeof id === 'undefined') return undefined;
 		return super.get(id);
 	}
 

--- a/src/structures/Items.ts
+++ b/src/structures/Items.ts
@@ -41,7 +41,7 @@ class Items extends Collection<number, Item | PartialItem> {
 
 	public get(item: ItemResolvable): Item | PartialItem | undefined {
 		const id = this.resolveID(item);
-		if (!id) return undefined;
+		if (!id && id !== 0) return undefined;
 		return super.get(id);
 	}
 


### PR DESCRIPTION
### Description:

-   ItemID 0 was being sent back by Items.get as undefined

### Changes:

-   Changes the check to allow ID 0

-   [X] I have tested all my changes thoroughly.
