### PR TITLE
Add Monocle to Elite Clue Loot Table

### DIFF
--- a/src/simulation/clues/Elite.ts
+++ b/src/simulation/clues/Elite.ts
@@ -113,6 +113,7 @@ export const EliteRareTable = new LootTable()
 	.add("Uri's hat")
 	.add('Giant boot')
 	.add("Rangers' tunic")
+	.add('Monocle')
 	.add(EliteMegaRareTable)
 	.add(EliteTuxedoTable);
 


### PR DESCRIPTION
### Description:

-   The Monocle is currently not possible to be obtained through Elite Clue Caskets. This should be a possible reward.
-   Fixes https://github.com/oldschoolgg/oldschoolbot/issues/1026 and fixes https://github.com/oldschoolgg/oldschoolbot/issues/950.

### Changes:

-   Adds Monocle to the Elite Clue Casket loot table.

-   [X] I have tested all my changes thoroughly.
