### PR TITLE
Fix drop tables on various monsters

### DIFF
--- a/src/simulation/monsters/bosses/slayer/AlchemicalHydra.ts
+++ b/src/simulation/monsters/bosses/slayer/AlchemicalHydra.ts
@@ -80,7 +80,7 @@ const NormalTable = new LootTable()
 const NormalUniqueTable = new LootTable()
 	.add(NormalTable)
 	.oneIn(181, "Hydra's eye")
-
+	.oneIn(514, 'Hydra leather')
 	.oneIn(513, 'Hydra tail')
 	.oneIn(1001, "Hydra's claw")
 	.oneIn(2000, 'Dragon thrownaxe', [500, 1000])

--- a/src/simulation/monsters/bosses/slayer/AlchemicalHydra.ts
+++ b/src/simulation/monsters/bosses/slayer/AlchemicalHydra.ts
@@ -78,13 +78,16 @@ const NormalTable = new LootTable()
 	.add(RareDropTable, 1, 1);
 
 const NormalUniqueTable = new LootTable()
-	.add(NormalTable)
-	.oneIn(181, "Hydra's eye")
-	.oneIn(514, 'Hydra leather')
-	.oneIn(513, 'Hydra tail')
-	.oneIn(1001, "Hydra's claw")
+	.every(NormalTable)
 	.oneIn(2000, 'Dragon thrownaxe', [500, 1000])
-	.oneIn(2001, 'Dragon knife', [500, 1000]);
+	.oneIn(2000, 'Dragon knife', [500, 1000])
+	.oneIn(1000, "Hydra's claw")
+	.oneIn(512, 'Hydra tail')
+	.oneIn(512, 'Hydra leather')
+	.oneIn(180, "Hydra's eye")
+	// These are so they show on the drop table, it's okay if they're rolled.
+	.oneIn(1_000_000, "Hydra's fang")
+	.oneIn(1_000_000, "Hydra's heart");
 
 const AlchemicalHydraTable = new LootTable()
 	.every(NormalUniqueTable)

--- a/src/simulation/monsters/low/a-f/FossilIslandWyvernAncient.ts
+++ b/src/simulation/monsters/low/a-f/FossilIslandWyvernAncient.ts
@@ -3,6 +3,10 @@ import SimpleMonster from '../../../../structures/SimpleMonster';
 import RareDropTable from '../../../subtables/RareDropTable';
 import TreeHerbSeedTable from '../../../subtables/TreeHerbSeedTable';
 
+const AncientWyvernTreeSeedTable = new LootTable()
+	.add('Mahogany seed', 1, 2)
+	.add('Magic seed', 1, 1);
+
 const AncientWyvernTable = new LootTable()
 	.every('Wyvern bones')
 	.oneIn(600, 'Granite longsword')
@@ -34,6 +38,10 @@ const AncientWyvernTable = new LootTable()
 
 	/* Seeds */
 	.add(TreeHerbSeedTable, 1, 4)
+	.add('Seaweed spore', [16, 24], 2)
+	.add('Ranarr seed', [2, 3], 1)
+	.add('Yew seed', 1, 2)
+	.add(AncientWyvernTreeSeedTable, 1, 2)
 
 	/* Materials 41/128 */
 	.add('Adamantite bar', 3, 12)

--- a/src/simulation/monsters/low/a-f/FossilIslandWyvernLongTailed.ts
+++ b/src/simulation/monsters/low/a-f/FossilIslandWyvernLongTailed.ts
@@ -31,6 +31,8 @@ const LongTailedWyvernTable = new LootTable()
 
 	/* Seeds */
 	.add(TreeHerbSeedTable, 1, 1)
+	.add('Seaweed spore', 12, 2)
+	.add('Ranarr seed', 1, 2)
 
 	/* Resources */
 	.add('Pure essence', 150, 8)

--- a/src/simulation/monsters/low/a-f/FossilIslandWyvernSpitting.ts
+++ b/src/simulation/monsters/low/a-f/FossilIslandWyvernSpitting.ts
@@ -31,6 +31,8 @@ const SpittingWyvernTable = new LootTable()
 
 	/* Seeds */
 	.add(TreeHerbSeedTable, 1, 1)
+	.add('Seaweed spore', 12, 2)
+	.add('Ranarr seed', 1, 2)
 
 	/* Resources */
 	.add('Pure essence', 150, 8)

--- a/src/simulation/monsters/low/a-f/FossilIslandWyvernTaloned.ts
+++ b/src/simulation/monsters/low/a-f/FossilIslandWyvernTaloned.ts
@@ -31,6 +31,8 @@ const TalonedWyvernTable = new LootTable()
 
 	/* Seeds */
 	.add(TreeHerbSeedTable, 1, 1)
+	.add('Seaweed spore', 12, 2)
+	.add('Ranarr seed', 1, 2)
 
 	/* Resources */
 	.add('Pure essence', 150, 8)

--- a/src/simulation/monsters/low/g-m/IceTroll.ts
+++ b/src/simulation/monsters/low/g-m/IceTroll.ts
@@ -2,7 +2,7 @@ import LootTable from '../../../../structures/LootTable';
 import SimpleMonster from '../../../../structures/SimpleMonster';
 import HerbDropTable from '../../../subtables/HerbDropTable';
 import { GemTable } from '../../../subtables/RareDropTable';
-import UncommonSeedDropTable from "../../../subtables/UncommonSeedDropTable";
+import UncommonSeedDropTable from '../../../subtables/UncommonSeedDropTable';
 
 const IceTrollTable = new LootTable()
 	.every('Big bones')
@@ -24,7 +24,7 @@ const IceTrollTable = new LootTable()
 
 	/* Herbs */
 	.add(HerbDropTable, 1, 2)
-	.add(UncommonSeedDropTable,1, 11)
+	.add(UncommonSeedDropTable, 1, 11)
 
 	/* Other */
 	.add('Coins', 200, 20)

--- a/src/simulation/monsters/low/g-m/IceTroll.ts
+++ b/src/simulation/monsters/low/g-m/IceTroll.ts
@@ -2,40 +2,38 @@ import LootTable from '../../../../structures/LootTable';
 import SimpleMonster from '../../../../structures/SimpleMonster';
 import HerbDropTable from '../../../subtables/HerbDropTable';
 import { GemTable } from '../../../subtables/RareDropTable';
+import UncommonSeedDropTable from "../../../subtables/UncommonSeedDropTable";
 
 const IceTrollTable = new LootTable()
 	.every('Big bones')
 
 	/* Weapons and armour */
-	.add('Adamant kiteshield', 1, 8)
-	.add('Black platebody', 1, 4)
-	.add('Adamant axe', 1, 2)
-	.add('Black warhammer', 1, 1)
-	.add('Mithril platebody', 1, 1)
-	.add('Rune battleaxe', 1, 1)
+	.add('Adamant full helm', 1, 10)
+	.add('Steel platebody', 1, 10)
+	.add('Mithril warhammer', 1, 5)
+	.add('Adamant axe', 1, 5)
+	.add('Rune kiteshield', 1, 2)
+	.add('Granite shield', 1, 1)
+	.add('Rune warhammer', 1, 1)
 
 	/* Runes */
-	.add('Blood rune', 2, 8)
-	.add('Blood rune', 5, 5)
-	.add('Law rune', 4, 3)
-	.add('Death rune', 15, 1)
-	.add('Water rune', 65, 1)
+	.add('Earth rune', [8, 14], 10)
+	.add('Earth rune', [12, 36], 10)
+	.add('Nature rune', [4, 12], 5)
+	.add('Law rune', [4, 8], 5)
 
 	/* Herbs */
-	.add(HerbDropTable, 1, 18)
-
-	/* Coins */
-	.add('Coins', 30, 29)
-	.add('Coins', 136, 25)
-	.add('Coins', 200, 10)
-	.add('Coins', 20, 4)
+	.add(HerbDropTable, 1, 2)
+	.add(UncommonSeedDropTable,1, 11)
 
 	/* Other */
-	.add('Lobster', 6, 3)
-	.add('Raw tuna', 4, 2)
+	.add('Coins', 200, 20)
+	.add('Raw shark', [2, 8], 10)
+	.add('Seaweed', [3, 9], 10)
+	.add('Ball of wool', [18, 42], 10)
 
 	/* Gem drop table */
-	.add(GemTable, 1, 8)
+	.add(GemTable, 1, 1)
 
 	/* Tertiary */
 	.tertiary(20, 'Ensouled troll head')

--- a/src/simulation/monsters/low/g-m/MithrilDragon.ts
+++ b/src/simulation/monsters/low/g-m/MithrilDragon.ts
@@ -49,5 +49,5 @@ export default new SimpleMonster({
 	id: 2919,
 	name: 'Mithril Dragon',
 	table: MithrilDragonTable,
-	aliases: ['mithril dragon', 'mith dragon']
+	aliases: ['mithril dragon', 'mith dragon', 'mith drags', 'mithril dragons']
 });

--- a/src/simulation/monsters/low/n-s/SmokeDevil.ts
+++ b/src/simulation/monsters/low/n-s/SmokeDevil.ts
@@ -62,5 +62,5 @@ export default new SimpleMonster({
 	id: 498,
 	name: 'Smoke Devil',
 	table: SmokeDevilTable,
-	aliases: ['smoke devil']
+	aliases: ['smoke devil', 'smokeys', 'smokies', 'smoke devils']
 });

--- a/src/simulation/monsters/low/t-z/UndeadCow.ts
+++ b/src/simulation/monsters/low/t-z/UndeadCow.ts
@@ -1,7 +1,7 @@
 import LootTable from '../../../../structures/LootTable';
 import SimpleMonster from '../../../../structures/SimpleMonster';
 
-export const UndeadCowTable = new LootTable().every('Bones').every('Cowhide').every('Raw beef');
+export const UndeadCowTable = new LootTable().every('Bones').every('Cowhide').every(4287);
 
 export default new SimpleMonster({
 	id: 2992,


### PR DESCRIPTION
### Description:
Fixed drop tables on the following monsters:
Ice Trolls
Undead cow
Fossil island wyverns (added missing seaweed spores and made minor fixes to the rest of the  table)

-   [x] I have tested all my changes thoroughly.
