### PR TITLE
Thermy + regular hydra drop tables

### DIFF
--- a/src/simulation/monsters/bosses/slayer/AlchemicalHydra.ts
+++ b/src/simulation/monsters/bosses/slayer/AlchemicalHydra.ts
@@ -3,6 +3,11 @@ import SimpleMonster from '../../../../structures/SimpleMonster';
 import RareDropTable from '../../../subtables/RareDropTable';
 import TreeHerbSeedTable from '../../../subtables/TreeHerbSeedTable';
 
+const AlchemicalHydraBrimstoneRingTable = new LootTable()
+	.add("Hydra's eye")
+	.add("Hydra's fang")
+	.add("Hydra's heart");
+
 const RuneArmourTable = new LootTable()
 	.every('Rune platebody')
 	.add('Rune platelegs')
@@ -84,10 +89,7 @@ const NormalUniqueTable = new LootTable()
 	.oneIn(1000, "Hydra's claw")
 	.oneIn(512, 'Hydra tail')
 	.oneIn(512, 'Hydra leather')
-	.oneIn(180, "Hydra's eye")
-	// These are so they show on the drop table, it's okay if they're rolled.
-	.oneIn(1_000_000, "Hydra's fang")
-	.oneIn(1_000_000, "Hydra's heart");
+	.oneIn(180, AlchemicalHydraBrimstoneRingTable);
 
 const AlchemicalHydraTable = new LootTable()
 	.every(NormalUniqueTable)

--- a/src/simulation/monsters/bosses/slayer/ThermonuclearSmokeDevil.ts
+++ b/src/simulation/monsters/bosses/slayer/ThermonuclearSmokeDevil.ts
@@ -61,6 +61,7 @@ const ThermonuclearSmokeDevilTable = new LootTable()
 	/* Tertiary */
 	.tertiary(96, 'Clue scroll (hard)')
 	.tertiary(500, 'Clue scroll (elite)')
+	.tertiary(2000, 'Jar of smoke')
 	.tertiary(3000, 'Pet smoke devil');
 
 export default new SimpleMonster({

--- a/src/simulation/monsters/low/a-f/CrawlingHand.ts
+++ b/src/simulation/monsters/low/a-f/CrawlingHand.ts
@@ -24,7 +24,8 @@ export const CrawlingHandPreTable = new LootTable()
 
 const CrawlingHandTable = new LootTable()
 	.every('Bones')
-	.tertiary(500, 'Crawling hand', 1)
+	// 7975 is the correct Crawling hand item
+	.tertiary(500, 7975, 1)
 	.every(CrawlingHandPreTable);
 
 export default new SimpleMonster({

--- a/src/simulation/monsters/low/a-f/Drake.ts
+++ b/src/simulation/monsters/low/a-f/Drake.ts
@@ -16,17 +16,17 @@ const DrakeNotedHerbTable = new LootTable()
 
 const DrakeOnTaskUniqueTable = new LootTable()
 	/* Pre-roll */
-	.oneIn(512, "Drake's tooth")
-	.oneIn(512, "Drake's claw")
 	.oneIn(2_000, 'Dragon thrownaxe', [100, 200])
-	.oneIn(2_000, 'Dragon knife', [100, 200]);
+	.oneIn(2_000, 'Dragon knife', [100, 200])
+	.oneIn(512, "Drake's tooth")
+	.oneIn(512, "Drake's claw");
 
 const DrakeOffTaskUniqueTable = new LootTable()
 	/* Pre-roll */
-	.oneIn(2_560, "Drake's tooth")
-	.oneIn(2_560, "Drake's claw")
 	.oneIn(10_000, 'Dragon thrownaxe', [100, 200])
-	.oneIn(10_000, 'Dragon knife', [100, 200]);
+	.oneIn(10_000, 'Dragon knife', [100, 200])
+	.oneIn(2_560, "Drake's tooth")
+	.oneIn(2_560, "Drake's claw");
 
 export const DrakePreTable = new LootTable()
 	/* Weapons and armour */

--- a/src/simulation/monsters/low/g-m/Hydra.ts
+++ b/src/simulation/monsters/low/g-m/Hydra.ts
@@ -6,18 +6,19 @@ import { GemTable } from '../../../subtables/RareDropTable';
 import RareSeedTable from '../../../subtables/RareSeedTable';
 
 const HydraOffTaskUniqueTable = new LootTable()
-	.oneIn(1_801, "Hydra's eye")
-
-	.oneIn(5_001, 'Hydra tail')
 	.oneIn(10_000, 'Dragon thrownaxe', [200, 400])
-	.oneIn(10_001, 'Dragon knife', [200, 400]);
+	.oneIn(10_000, 'Dragon knife', [200, 400])
+	.oneIn(5_000, 'Hydra tail')
+	.oneIn(1_800, "Hydra's eye")
+	// so they show up on the drop table:
+	.oneIn(1_000_000, "Hydra's fang")
+	.oneIn(1_000_000, "Hydra's heart");
 
 const HydraOnTaskUniqueTable = new LootTable()
-	.oneIn(1_801, "Hydra's eye")
-
-	.oneIn(5_001, 'Hydra tail')
-	.oneIn(10_000, 'Dragon thrownaxe', [200, 400])
-	.oneIn(10_001, 'Dragon knife', [200, 400]);
+	.oneIn(2_000, 'Dragon thrownaxe', [200, 400])
+	.oneIn(2_000, 'Dragon knife', [200, 400])
+	.oneIn(1_000, 'Hydra tail')
+	.oneIn(360, "Hydra's eye");
 
 export const HydraPreTable = new LootTable()
 	/* Weapons and armour */

--- a/src/simulation/monsters/low/g-m/Hydra.ts
+++ b/src/simulation/monsters/low/g-m/Hydra.ts
@@ -5,20 +5,22 @@ import { NotedHerbTable } from '../../../subtables/NotedHerbTable';
 import { GemTable } from '../../../subtables/RareDropTable';
 import RareSeedTable from '../../../subtables/RareSeedTable';
 
+const HydraBrimstoneRingTable = new LootTable()
+	.add("Hydra's eye")
+	.add("Hydra's fang")
+	.add("Hydra's heart");
+
 const HydraOffTaskUniqueTable = new LootTable()
 	.oneIn(10_000, 'Dragon thrownaxe', [200, 400])
 	.oneIn(10_000, 'Dragon knife', [200, 400])
 	.oneIn(5_000, 'Hydra tail')
-	.oneIn(1_800, "Hydra's eye")
-	// so they show up on the drop table:
-	.oneIn(1_000_000, "Hydra's fang")
-	.oneIn(1_000_000, "Hydra's heart");
+	.oneIn(1_800, HydraBrimstoneRingTable);
 
 const HydraOnTaskUniqueTable = new LootTable()
 	.oneIn(2_000, 'Dragon thrownaxe', [200, 400])
 	.oneIn(2_000, 'Dragon knife', [200, 400])
 	.oneIn(1_000, 'Hydra tail')
-	.oneIn(360, "Hydra's eye");
+	.oneIn(360, HydraBrimstoneRingTable);
 
 export const HydraPreTable = new LootTable()
 	/* Weapons and armour */

--- a/src/simulation/monsters/low/t-z/Wyrm.ts
+++ b/src/simulation/monsters/low/t-z/Wyrm.ts
@@ -6,17 +6,17 @@ import RareSeedTable from '../../../subtables/RareSeedTable';
 
 const WyrmOnTaskUniqueTable = new LootTable()
 	/* Pre-roll*/
-	.oneIn(2_000, 'Dragon sword')
-	.oneIn(2_000, 'Dragon harpoon')
 	.oneIn(2_000, 'Dragon knife', [75, 150])
-	.oneIn(2_000, 'Dragon thrownaxe', [75, 150]);
+	.oneIn(2_000, 'Dragon thrownaxe', [75, 150])
+	.oneIn(2_000, 'Dragon sword')
+	.oneIn(2_000, 'Dragon harpoon');
 
 const WyrmOffTaskUniqueTable = new LootTable()
 	/* Pre-roll*/
-	.oneIn(10_000, 'Dragon sword')
-	.oneIn(10_000, 'Dragon harpoon')
 	.oneIn(10_000, 'Dragon knife', [75, 150])
-	.oneIn(10_000, 'Dragon thrownaxe', [75, 150]);
+	.oneIn(10_000, 'Dragon thrownaxe', [75, 150])
+	.oneIn(10_000, 'Dragon sword')
+	.oneIn(10_000, 'Dragon harpoon');
 
 export const WyrmPreTable = new LootTable({ limit: 76 })
 	/* Weapons and armour */


### PR DESCRIPTION
### Description:
Fix regular hydra tables, as well as thermy.

### Changes:
/edit: Fixed hydra + boss hydra drop tables the right way.
Drop rates were incorrect on regular hydra's on-task table
Minor adjustment to rates on both on+off task hydra to match game more closely
Added Jar of smoke to thermy
