### PR TITLE
Default to tradeable versions of items in itemNameMap

### DIFF
--- a/src/structures/Items.ts
+++ b/src/structures/Items.ts
@@ -56,7 +56,7 @@ for (const [id, item] of Object.entries(items)) {
 	if (USELESS_ITEMS.includes(numID)) continue;
 	itemsExport.set(numID, item);
 	const cleanName = cleanString(item.name);
-	if (!itemNameMap.has(cleanName)) itemNameMap.set(cleanName, numID);
+	if (!itemNameMap.has(cleanName) || (!items[itemNameMap.get(cleanName)].tradeable && item.tradeable)) itemNameMap.set(cleanName, numID);
 }
 
 export default itemsExport;


### PR DESCRIPTION
### Description:

-   Whenever using item names to fetch items, multiple items with the same name will default to the first tradeable version it finds.
