### PR TITLE
Correct ancient shard drop rate to in game values

### DIFF
--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -176,7 +176,7 @@ export function convertLootBanksToItemBanks(lootResult: LootBank): Record<string
 }
 
 export function getAncientShardChanceFromHP(hitpoints: number): number {
-	return Math.round((500 - hitpoints) / 3);
+	return Math.round((500 - hitpoints) / 1.5);
 }
 export function getTotemChanceFromHP(hitpoints: number): number {
 	return 500 - hitpoints;


### PR DESCRIPTION
### Description:

-   Ancient shards drop at 2x the rate than they should compared to in game. This corrects that. Checked the math against about 10 monsters, it checks out.
