### PR TITLE
Add plurals to monster aliases

### DIFF
--- a/src/structures/Monster.ts
+++ b/src/structures/Monster.ts
@@ -18,5 +18,9 @@ export default abstract class Monster {
 		this.aliases = options.aliases ?? [];
 		this.data = monsterData[this.id];
 		this.allItems = options.allItems;
+		const pluralName = this.name.toLowerCase() + 's';
+		if (!this.aliases.includes(pluralName)) {
+			this.aliases.push(pluralName);
+		}
 	}
 }


### PR DESCRIPTION
### Description:

-  Adds plural aliases to any monster that doesn't have one defined already. Fixes slayer blocks showing "Black demons" but not having the plural demons as an alias, but for all monsters.
