### PR TITLE
Refactor the SimpleMonster.kill() drops the right way

### DIFF
--- a/src/simulation/monsters/low/g-m/Gargoyle.ts
+++ b/src/simulation/monsters/low/g-m/Gargoyle.ts
@@ -42,9 +42,16 @@ const GargoyleTable = new LootTable()
 	/* Tertiary */
 	.tertiary(128, 'Clue scroll (hard)');
 
+const GargoyleOnTaskTable = new LootTable()
+	.every(GargoyleTable)
+
+	/* Brittle key can only drop on task */
+	.tertiary(150, 'Brittle key');
+
 export default new SimpleMonster({
 	id: 412,
 	name: 'Gargoyle',
 	table: GargoyleTable,
+	onTaskTable: GargoyleOnTaskTable,
 	aliases: ['gargoyle', 'garg', 'gargs']
 });

--- a/src/structures/SimpleMonster.ts
+++ b/src/structures/SimpleMonster.ts
@@ -50,9 +50,6 @@ export default class SimpleMonster extends Monster {
 					loot.add('Brimstone key');
 				}
 			}
-			if (options.onSlayerTask && this.name.toLowerCase() === 'gargoyle' && roll(150)) {
-				loot.add('Brittle key');
-			}
 			if (options.inCatacombs) {
 				if (roll(getAncientShardChanceFromHP(this.data.hitpoints))) {
 					loot.add('Ancient shard');
@@ -63,13 +60,7 @@ export default class SimpleMonster extends Monster {
 				}
 			}
 			if (options.onSlayerTask) {
-				if (options.hasSuperiors && roll(200)) {
-					// Superiors always drop totem piece in catacombs.
-					if (options.inCatacombs) loot.add('Dark totem base');
-					// track number of superiors with this item (Distillator).
-					loot.add({ [420]: 1 });
-					loot.add(options.hasSuperiors.table.roll());
-				} else if (this.onTaskTable) {
+				if (this.onTaskTable) {
 					// Roll the monster's "on-task" table.
 					loot.add(this.onTaskTable.roll());
 				} else {


### PR DESCRIPTION
### Description:

-   Refactor the way superiors and brittle keys are dropped from the SimpleMonster.kill() function.
Linked to OSB: https://github.com/oldschoolgg/oldschoolbot/pull/2278


### Changes:

-   Superiors are now calculated in OSB and not in OSJS
-   Brittle key is now on the task-only table of Gargoyles instead of in the kill() function

-   [x] I have tested all my changes thoroughly.
