### PR TITLE
Fix tests by adding missing boss to hiscores

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -60,6 +60,7 @@ export const mappedBossNames: [string, string][] = [
 	['krilTsutsaroth', "K'ril Tsutsaroth"],
 	['mimic', 'Mimic'],
 	['nightmare', 'The Nightmare'],
+	['phosanisNightmare', "Phosani's Nightmare"],
 	['obor', 'Obor'],
 	['sarachnis', 'Sarachnis'],
 	['scorpia', 'Scorpia'],


### PR DESCRIPTION
### Description:
Phosani's nightmare was recently added to the hiscores breaking the Hiscores and thus the tests.

### Changes:

-   Added Phosani's nightmare to the list of bosses

-   [x] I have tested all my changes thoroughly.
