### PR TITLE
Loot table limit error throw

### DIFF
--- a/src/structures/LootTable.ts
+++ b/src/structures/LootTable.ts
@@ -123,6 +123,9 @@ export default class LootTable {
 		quantity: number[] | number = 1,
 		weight = 1
 	): this {
+		if (this.limit && weight + this.totalWeight > this.limit) {
+			throw new Error('Loot table total weight exceeds limit');
+		}
 		if (typeof item === 'string') {
 			return this.add(this.resolveName(item), quantity, weight);
 		}


### PR DESCRIPTION

### Description:

If limit is below total weight, items become silently unobtainable or lower drop rate (depending on if the limit is partially or fully exceeded)

-   [X] I have tested all my changes thoroughly.
