### PR TITLE
Fix Beared Pollnivnian Bandit's drop tables

### DIFF
--- a/src/simulation/monsters/low/a-f/BeardedBandit.ts
+++ b/src/simulation/monsters/low/a-f/BeardedBandit.ts
@@ -4,10 +4,7 @@ import SimpleMonster from '../../../../structures/SimpleMonster';
 export default new SimpleMonster({
 	id: 736,
 	name: 'Bearded Pollnivnian Bandit',
-	table: new LootTable({ limit: 5 })
-		.every('Bones')
-		.add('Coins', [10, 300])
-		.tertiary(257_211, 'Rocky'),
-	pickpocketTable: new LootTable().add('Coins', 40),
-	aliases: ['bearded pollnivnian bandit', 'pollnivnian bandit']
+	table: new LootTable({ limit: 5 }).every('Bones').add('Coins', [10, 300]),
+	pickpocketTable: new LootTable().add('Coins', 40).tertiary(257_211, 'Rocky'),
+	aliases: ['bearded pollnivnian bandit', 'pollnivnian bandit', 'bearded bandit']
 });


### PR DESCRIPTION
### Description / Changes:

-   Add Rocky to the bandit's pickpocket table
-   Remove Rocky from the bandit's kill loot table
-   Added 'bearded bandit' alias because no-one can remember how to spell Pollnivnian 


-   I did not test this in the bot, but I did search for alias conflicts and ran `yarn test`
**-   Yarn test fails btw because Seasonal high scores were reset, so there's no account found.**
