### PR TITLE
Fixing pickpocket Pollnivnian vs Bearded conflict 

### DIFF
--- a/src/simulation/monsters/low/a-f/BeardedBandit.ts
+++ b/src/simulation/monsters/low/a-f/BeardedBandit.ts
@@ -6,5 +6,5 @@ export default new SimpleMonster({
 	name: 'Bearded Pollnivnian Bandit',
 	table: new LootTable({ limit: 5 }).every('Bones').add('Coins', [10, 300]),
 	pickpocketTable: new LootTable().add('Coins', 40).tertiary(257_211, 'Rocky'),
-	aliases: ['bearded pollnivnian bandit', 'pollnivnian bandit', 'bearded bandit']
+	aliases: ['bearded pollnivnian bandit', 'bearded bandit']
 });

--- a/src/simulation/monsters/low/n-s/PollnivnianBandit.ts
+++ b/src/simulation/monsters/low/n-s/PollnivnianBandit.ts
@@ -2,7 +2,7 @@ import LootTable from '../../../../structures/LootTable';
 import SimpleMonster from '../../../../structures/SimpleMonster';
 
 export default new SimpleMonster({
-	id: 736,
+	id: 735,
 	name: 'Bandit',
 	pickpocketTable: new LootTable().add('Coins', 50),
 	aliases: ['pollnivnian bandit', 'bandit']


### PR DESCRIPTION
### Description:

-  Thieving would opt to pickpocket lvl 45 bearded bandits instead of 55 pollnivnian bandits due to conflicting aliases and matching mosters.id

### Changes:

-   Removed 'Pollnivnian bandit' as alias causing conflicts in thieving code. Changed pollnivian bandit id to 735 (non bearded)

-   [x] I have tested all my changes thoroughly.
