### PR TITLE
Add demonic ashes to simulations

### DIFF
--- a/src/simulation/misc/Zalcano.ts
+++ b/src/simulation/misc/Zalcano.ts
@@ -93,7 +93,7 @@ class ZalcanoClass {
 			const loot = new Bank();
 			loot.add(...this.rollNonUniqueLoot(teamMember.performancePercentage, teamMember.isMVP));
 			if (teamMember.isMVP) {
-				loot.add('Ashes');
+				loot.add('Infernal ashes');
 				loot.add('Crystal shard', 3);
 			} else {
 				loot.add('Crystal shard', 2);

--- a/src/simulation/monsters/bosses/KrilTsutsaroth.ts
+++ b/src/simulation/monsters/bosses/KrilTsutsaroth.ts
@@ -9,7 +9,7 @@ const MinionUniqueTable = new LootTable()
 const MinionShardTable = new LootTable().add('Coins', [1_300, 1_400], 9).add(ShardTable, 1, 3);
 
 const MinionTable = new LootTable()
-	.every('Ashes')
+	.every('Malicious ashes')
 	.add(MinionUniqueTable, 1, 1)
 	.add(MinionShardTable, 1, 1)
 	.add('Steel dart', [95, 100], 8)
@@ -36,7 +36,7 @@ const UniqueTable = new LootTable()
 	.add(ShardTable, 1, 2);
 
 const KrilTsutsarothTable = new LootTable()
-	.every('Ashes')
+	.every('Infernal ashes')
 	.every(MinionTable, 2)
 	.every(ZaklnGritchMinionTable)
 	.add(UniqueTable, 1, 3)

--- a/src/simulation/monsters/bosses/Skotizo.ts
+++ b/src/simulation/monsters/bosses/Skotizo.ts
@@ -9,7 +9,7 @@ const AncientShardTable = new LootTable({ limit: 100 })
 	.add('Ancient shard', 5, 1);
 
 const SkotizoTable = new LootTable()
-	.every('Ashes')
+	.every('Infernal ashes')
 	.every('Clue scroll (hard)')
 	.every(AncientShardTable)
 

--- a/src/simulation/monsters/bosses/slayer/AbyssalSire.ts
+++ b/src/simulation/monsters/bosses/slayer/AbyssalSire.ts
@@ -11,7 +11,7 @@ const HerbSubTable = new LootTable()
 	.add('Grimy lantadyme', 25, 7);
 
 const AbyssalSireTable = new LootTable()
-	.every('Ashes')
+	.every('Abyssal ashes')
 
 	/* Weapons and armour */
 	.add('Battlestaff', 10, 6)

--- a/src/simulation/monsters/bosses/slayer/Cerberus.ts
+++ b/src/simulation/monsters/bosses/slayer/Cerberus.ts
@@ -9,7 +9,7 @@ const CerberusUniqueTable = new LootTable()
 	.add('Smouldering stone');
 
 const CerberusTable = new LootTable()
-	.every('Ashes')
+	.every('Infernal ashes')
 	.add(CerberusUniqueTable)
 	.tertiary(100, 'Clue scroll (elite)')
 	.tertiary(2000, 'Jar of souls')

--- a/src/simulation/monsters/low/a-f/AbyssalDemon.ts
+++ b/src/simulation/monsters/low/a-f/AbyssalDemon.ts
@@ -44,7 +44,7 @@ export const AbyssalDemonPreTable = new LootTable()
 	.add(GemTable, 1, 5);
 
 const AbyssalDemonTable = new LootTable()
-	.every('Ashes')
+	.every('Abyssal ashes')
 	.every(AbyssalDemonPreTable)
 
 	/* Tertiary */

--- a/src/simulation/monsters/low/a-f/BlackDemon.ts
+++ b/src/simulation/monsters/low/a-f/BlackDemon.ts
@@ -4,7 +4,7 @@ import HerbDropTable from '../../../subtables/HerbDropTable';
 import RareDropTable, { GemTable } from '../../../subtables/RareDropTable';
 
 const BlackDemonTable = new LootTable()
-	.every('Ashes')
+	.every('Malicious ashes')
 
 	/* Weapons and armour */
 	.add('Black sword', 1, 4)

--- a/src/simulation/monsters/low/a-f/Bloodveld.ts
+++ b/src/simulation/monsters/low/a-f/Bloodveld.ts
@@ -53,7 +53,7 @@ export const BloodveldPreTable = new LootTable()
 	.add(GemTable, 1, 4);
 
 const BloodveldTable = new LootTable()
-	.every('Bones')
+	.every('Vile ashes')
 	.every(BloodveldPreTable)
 
 	/* Tertiary */

--- a/src/simulation/monsters/low/a-f/DemonicGorilla.ts
+++ b/src/simulation/monsters/low/a-f/DemonicGorilla.ts
@@ -13,7 +13,7 @@ const UniqueTable = new LootTable()
 	.add('Monkey tail', 1, 1);
 
 const DemonicGorillaTable = new LootTable({ limit: 500 })
-	.every('Ashes')
+	.every('Malicious ashes')
 
 	.add(UniqueTable, 1, 5)
 

--- a/src/simulation/monsters/low/g-m/GreaterDemon.ts
+++ b/src/simulation/monsters/low/g-m/GreaterDemon.ts
@@ -3,7 +3,7 @@ import SimpleMonster from '../../../../structures/SimpleMonster';
 import { GemTable } from '../../../subtables/RareDropTable';
 
 const GreaterDemonTable = new LootTable({ limit: 128 })
-	.every('Ashes')
+	.every('Vile ashes')
 
 	/* Weapons and armor */
 	.add('Steel 2h sword', 1, 4)

--- a/src/simulation/monsters/low/g-m/GreaterNechryael.ts
+++ b/src/simulation/monsters/low/g-m/GreaterNechryael.ts
@@ -5,7 +5,7 @@ import { GemTable } from '../../../subtables/RareDropTable';
 import RareSeedTable from '../../../subtables/RareSeedTable';
 
 const GreaterNechryaelTable = new LootTable()
-	.every('Ashes')
+	.every('Malicious ashes')
 
 	/* Weapons and armor */
 	.add('Adamant kiteshield', 1, 7)

--- a/src/simulation/monsters/low/g-m/Hellhound.ts
+++ b/src/simulation/monsters/low/g-m/Hellhound.ts
@@ -2,7 +2,7 @@ import LootTable from '../../../../structures/LootTable';
 import SimpleMonster from '../../../../structures/SimpleMonster';
 
 const HellhoundTable = new LootTable()
-	.every('Bones')
+	.every('Vile ashes')
 	.oneIn(32_768, 'Smouldering stone')
 	.tertiary(64, 'Clue scroll (hard)');
 

--- a/src/simulation/monsters/low/g-m/Imp.ts
+++ b/src/simulation/monsters/low/g-m/Imp.ts
@@ -4,7 +4,7 @@ import SimpleMonster from '../../../../structures/SimpleMonster';
 export const ImpTable = new LootTable()
 	.tertiary(5000, 'Imp champion scroll')
 	.tertiary(25, 'Ensouled imp head')
-	.every('Ashes')
+	.every('Fiendish ashes')
 	.add('Black bead', 1, 5)
 	.add('Red bead', 1, 5)
 	.add('White bead', 1, 5)

--- a/src/simulation/monsters/low/g-m/LesserDemon.ts
+++ b/src/simulation/monsters/low/g-m/LesserDemon.ts
@@ -4,7 +4,7 @@ import HerbDropTable from '../../../subtables/HerbDropTable';
 import { GemTable } from '../../../subtables/RareDropTable';
 
 const LesserDemonTable = new LootTable()
-	.every('Ashes')
+	.every('Vile ashes')
 
 	/* Weapons and armor*/
 	.add('Steel full helm', 1, 4)

--- a/src/simulation/monsters/low/g-m/MutatedBloodveld.ts
+++ b/src/simulation/monsters/low/g-m/MutatedBloodveld.ts
@@ -39,7 +39,7 @@ export const MutatedBloodveldPreTable = new LootTable()
 	.add(GemTable, 1, 2);
 
 const MutatedBloodveldTable = new LootTable()
-	.every('Bones')
+	.every('Vile ashes')
 	.every(MutatedBloodveldPreTable)
 
 	/* Tertiary */

--- a/src/simulation/monsters/low/n-s/Nechryael.ts
+++ b/src/simulation/monsters/low/n-s/Nechryael.ts
@@ -39,7 +39,7 @@ export const NechryaelPreTable = new LootTable()
 	.add(GemTable, 1, 10);
 
 const NechryaelTable = new LootTable()
-	.every('Ashes')
+	.every('Malicious ashes')
 	.every(NechryaelPreTable)
 
 	/* Tertiary */

--- a/src/simulation/monsters/low/n-s/Pyrefiend.ts
+++ b/src/simulation/monsters/low/n-s/Pyrefiend.ts
@@ -32,7 +32,7 @@ export const PyrefiendPreTable = new LootTable()
 	.add(GemTable, 1, 3);
 
 const PyrefiendTable = new LootTable()
-	.every('Ashes')
+	.every('Fiendish ashes')
 	.every(PyrefiendPreTable)
 
 	/* Tertiary */

--- a/src/simulation/monsters/low/n-s/Pyrelord.ts
+++ b/src/simulation/monsters/low/n-s/Pyrelord.ts
@@ -32,7 +32,7 @@ export const PyrelordPreTable = new LootTable()
 	.add(GemTable, 1, 3);
 
 const PyrelordTable = new LootTable()
-	.every('Ashes')
+	.every('Fiendish ashes')
 	.every(PyrelordPreTable)
 
 	/* Tertiary */

--- a/src/simulation/monsters/low/t-z/Waterfiend.ts
+++ b/src/simulation/monsters/low/t-z/Waterfiend.ts
@@ -6,6 +6,7 @@ import RareSeedTable from '../../../subtables/RareSeedTable';
 
 const WaterfiendTable = new LootTable()
 	.every('Water rune')
+	.every('Fiendish ashes')
 
 	/* Pre-roll */
 	.oneIn(3000, 'Mist battlestaff')

--- a/src/simulation/monsters/superiorMonsters/FlamingPyrelord.ts
+++ b/src/simulation/monsters/superiorMonsters/FlamingPyrelord.ts
@@ -3,7 +3,7 @@ import SimpleMonster from '../../../structures/SimpleMonster';
 import { PyrefiendPreTable } from '../low/n-s/Pyrefiend';
 
 const FlamingPyrelordTable = new LootTable()
-	.every('Ashes')
+	.every('Fiendish ashes')
 	.every(PyrefiendPreTable, 3)
 
 	/* Tertiary */

--- a/src/simulation/monsters/superiorMonsters/GreaterAbyssalDemon.ts
+++ b/src/simulation/monsters/superiorMonsters/GreaterAbyssalDemon.ts
@@ -3,7 +3,7 @@ import SimpleMonster from '../../../structures/SimpleMonster';
 import { AbyssalDemonPreTable } from '../low/a-f/AbyssalDemon';
 
 const GreaterAbyssalDemonTable = new LootTable()
-	.every('Ashes')
+	.every('Abyssal ashes')
 	.every('Ensouled abyssal head')
 	.every(AbyssalDemonPreTable, 3)
 	.tertiary(13, 'Clue scroll (hard)')

--- a/src/simulation/monsters/superiorMonsters/InsatiableBloodveld.ts
+++ b/src/simulation/monsters/superiorMonsters/InsatiableBloodveld.ts
@@ -3,7 +3,7 @@ import SimpleMonster from '../../../structures/SimpleMonster';
 import { BloodveldPreTable } from '../low/a-f/Bloodveld';
 
 const InsatiableBloodveldTable = new LootTable()
-	.every('Bones')
+	.every('Vile ashes')
 	.every('Ensouled bloodveld head')
 	.every(BloodveldPreTable, 3)
 	.tertiary(26, 'Clue scroll (hard)')

--- a/src/simulation/monsters/superiorMonsters/InsatiableMutatedBloodveld.ts
+++ b/src/simulation/monsters/superiorMonsters/InsatiableMutatedBloodveld.ts
@@ -3,7 +3,7 @@ import SimpleMonster from '../../../structures/SimpleMonster';
 import { MutatedBloodveldPreTable } from '../low/g-m/MutatedBloodveld';
 
 const InsatiableMutatedBloodveldTable = new LootTable()
-	.every('Bones')
+	.every('Vile ashes')
 	.every('Ensouled bloodveld head')
 	.every(MutatedBloodveldPreTable, 3)
 	.tertiary(13, 'Clue scroll (hard)')

--- a/src/simulation/monsters/superiorMonsters/Nechryarch.ts
+++ b/src/simulation/monsters/superiorMonsters/Nechryarch.ts
@@ -3,7 +3,7 @@ import SimpleMonster from '../../../structures/SimpleMonster';
 import { NechryaelPreTable } from '../low/n-s/Nechryael';
 
 const NechryarchTable = new LootTable()
-	.every('Ashes')
+	.every('Malicious ashes')
 	.every(NechryaelPreTable, 3)
 	.tertiary(13, 'Clue scroll (hard)')
 


### PR DESCRIPTION
### Description:

Add the demonic ashes to the loot tables of relevant monsters based on wiki drop tables.

### Changes:

-  Add Fiendish ashes to Imp, Pyrefiend, Pyrelord, Waterfiend and Flaming Pyrelord
-  Add Vile ashes to Bloodveld, Greater Demon, Hellhound, Lesser Demon, Mutated Bloodveld, Insatiable Bloodveld and Insatiable Mutated Bloodveld.
-  Add Malicious ashes to Kril minions, Black Demon, Demonic Gorilla, Greater Nechryael, Nechryael and Nechryarch.
-  Add Abyssal ashes to Abyssal Sire, Abyssal Demon and Greater Abyssal Demon.
-  Add Infernal ashes to Kril, Zalcano, Skotizo and Cerberus.

-   [x] I have tested all my changes thoroughly.
