### PR TITLE
Update elite clue mega rare chance

### DIFF
--- a/src/simulation/clues/Elite.ts
+++ b/src/simulation/clues/Elite.ts
@@ -114,7 +114,7 @@ export const EliteRareTable = new LootTable()
 	.add('Giant boot')
 	.add("Rangers' tunic")
 	.add('Monocle')
-	.add(EliteMegaRareTable)
+	.add(EliteMegaRareTable, 1, 2)
 	.add(EliteTuxedoTable);
 
 export const EliteSeedTable = new LootTable().add('Magic seed').add('Yew seed').add('Palm tree seed');


### PR DESCRIPTION
### Description:

-   Currently, the elite clue drop table is not consistent with OSRS as it does not include the mega rare table buff from Poll 76. The tweet from Mod Ash below explains how they implemented the buff in-game. This yields a 3rd age chance per roll of 1/14,662.5 despite the poll promising 1/13750. The relevant wiki page is also included below.

https://twitter.com/JagexAsh/status/1529773495588208641
https://oldschool.runescape.wiki/w/Reward_casket_(elite)#Mega_rare_table_-_Elite_clues

### Changes:

-   Changed the mega rare table chance within the elite rare table to 2/51 from 1/50 (consistent with OSRS).

-   [] I have tested all my changes thoroughly.
