### PR TITLE
Add missing bossRecords

### DIFF
--- a/src/meta/types.ts
+++ b/src/meta/types.ts
@@ -98,13 +98,18 @@ export interface BossRecords {
 	mimic: MinigameScore;
 	nex: MinigameScore;
 	nightmare: MinigameScore;
+	phosanisNightmare: MinigameScore;
 	sarachnis: MinigameScore;
 	scorpia: MinigameScore;
 	skotizo: MinigameScore;
+	tempoross: MinigameScore;
 	theGauntlet: MinigameScore;
 	theCorruptedGauntlet: MinigameScore;
 	theatreofBlood: MinigameScore;
+	theatreofBloodHard: MinigameScore;
 	thermonuclearSmokeDevil: MinigameScore;
+	tombsofAmascut: MinigameScore;
+	tombsofAmascutExpert: MinigameScore;
 	tzKalZuk: MinigameScore;
 	tzTokJad: MinigameScore;
 	venenatis: MinigameScore;


### PR DESCRIPTION
### Description:

The bossRecords interface is missing a few boss fields. I added the missing ones with their names taken from `mappedBossNames`.

### Changes:

Added these records to the bossRecords interface
- phosanisNightmare
- tempoross
- theatreofBloodHard
- tombsofAmascut
- tombsofAmascutExpert
