### PR TITLE
Fix drop table for Rogue

### DIFF
--- a/src/simulation/monsters/low/n-s/Rogue.ts
+++ b/src/simulation/monsters/low/n-s/Rogue.ts
@@ -3,7 +3,7 @@ import SimpleMonster from '../../../../structures/SimpleMonster';
 
 const RogueTable = new LootTable()
 	// Weaponry
-	.add('Iron dagger(p)', 9, 1 / 128)
+	.add('Iron dagger(p)', 1, 1 / 128)
 
 	// Other
 	.add('Coins', [25, 40], 1 / 1.185)


### PR DESCRIPTION
### Description:

According to the Oldschool RuneScape wiki, Rogue [drops (1)](https://oldschool.runescape.wiki/w/Rogue#Weaponry) Iron dagger(p), and not (9).

This fixes issue #309 

### Changes:

- Rogue will now drop (1) Iron dagger(p)

- [x] I have tested all my changes thoroughly.