### PR TITLE
Update jar of darkness rate

### DIFF
--- a/src/simulation/monsters/bosses/Skotizo.ts
+++ b/src/simulation/monsters/bosses/Skotizo.ts
@@ -49,7 +49,7 @@ const SkotizoTable = new LootTable()
 	.tertiary(128, 'Dark totem base')
 	.tertiary(128, 'Dark totem base')
 	.tertiary(128, 'Dark totem')
-	.tertiary(2500, 'Jar of darkness');
+	.tertiary(200, 'Jar of darkness');
 
 export default new SimpleMonster({
 	id: 7286,


### PR DESCRIPTION
Following the successful osrs poll, updates the jar of darkness to the correct rate.

https://secure.runescape.com/m=poll/oldschool/results?id=1649

(This will stay in draft until the change is live in game)
