### PR TITLE
Enable solo ToB for finish command

### DIFF
--- a/src/simulation/misc/TheatreOfBlood.ts
+++ b/src/simulation/misc/TheatreOfBlood.ts
@@ -163,8 +163,8 @@ export class TheatreOfBloodClass {
 
 	public complete(_options: TheatreOfBloodOptions) {
 		const options = JSONClone(_options);
-		if (options.team.length < 2 || options.team.length > 4) {
-			throw new Error('Only team sizes of 2-4 are supported in ToB');
+		if (options.team.length < 1 || options.team.length > 4) {
+			throw new Error('Only team sizes of 1-4 are supported in ToB');
 		}
 
 		const maxPointsPerPerson = 22;


### PR DESCRIPTION
### Description:

/finish fails in osbot for Solo HM ToB because OSJS doesn't support 1 player ToB

### Changes:

-   enables 1 player teams

-   [] I have tested all my changes thoroughly.
