### PR TITLE
Add Scaly blue dragonhide to drop tables

### DIFF
--- a/src/simulation/monsters/bosses/Vorkath.ts
+++ b/src/simulation/monsters/bosses/Vorkath.ts
@@ -61,6 +61,7 @@ const VorkathTable = new LootTable()
 
 const TotalVorkathTable = new LootTable()
 	.every(VorkathTable, 2)
+	.tertiary(10, 'Scaly blue dragonhide')
 	.tertiary(50, 21_907) // Vorkath's head, exists twice, this is the head with 50k worth
 	.tertiary(65, 'Clue scroll (elite)')
 	.tertiary(1000, 'Dragonbone necklace')

--- a/src/simulation/monsters/low/a-f/BabyBlackDragon.ts
+++ b/src/simulation/monsters/low/a-f/BabyBlackDragon.ts
@@ -1,7 +1,11 @@
 import LootTable from '../../../../structures/LootTable';
 import SimpleMonster from '../../../../structures/SimpleMonster';
 
-const BabyBlackDragon = new LootTable().every('Babydragon bones');
+const BabyBlackDragon = new LootTable()
+	.every('Babydragon bones')
+
+	/* Tertiary */
+	.tertiary(10, 'Scaly blue dragonhide');
 
 export default new SimpleMonster({
 	id: 1871,

--- a/src/simulation/monsters/low/a-f/BabyBlackDragon.ts
+++ b/src/simulation/monsters/low/a-f/BabyBlackDragon.ts
@@ -1,11 +1,7 @@
 import LootTable from '../../../../structures/LootTable';
 import SimpleMonster from '../../../../structures/SimpleMonster';
 
-const BabyBlackDragon = new LootTable()
-	.every('Babydragon bones')
-
-	/* Tertiary */
-	.tertiary(100, 'Scaly blue dragonhide');
+const BabyBlackDragon = new LootTable().every('Babydragon bones');
 
 export default new SimpleMonster({
 	id: 1871,

--- a/src/simulation/monsters/low/a-f/BabyBlackDragon.ts
+++ b/src/simulation/monsters/low/a-f/BabyBlackDragon.ts
@@ -5,7 +5,7 @@ const BabyBlackDragon = new LootTable()
 	.every('Babydragon bones')
 
 	/* Tertiary */
-	.tertiary(10, 'Scaly blue dragonhide');
+	.tertiary(100, 'Scaly blue dragonhide');
 
 export default new SimpleMonster({
 	id: 1871,

--- a/src/simulation/monsters/low/a-f/BabyBlueDragon.ts
+++ b/src/simulation/monsters/low/a-f/BabyBlueDragon.ts
@@ -1,7 +1,11 @@
 import LootTable from '../../../../structures/LootTable';
 import SimpleMonster from '../../../../structures/SimpleMonster';
 
-const BabyBlueDragonTable = new LootTable().every('Babydragon bones');
+const BabyBlueDragonTable = new LootTable()
+	.every('Babydragon bones')
+
+	/* Tertiary */
+	.tertiary(100, 'Scaly blue dragonhide');
 
 export default new SimpleMonster({
 	id: 241,

--- a/src/simulation/monsters/low/a-f/BlueDragon.ts
+++ b/src/simulation/monsters/low/a-f/BlueDragon.ts
@@ -41,6 +41,7 @@ const BlueDragonTable = new LootTable()
 
 	/* Tertiary */
 	.tertiary(50, 'Ensouled dragon head')
+	.tertiary(50, 'Scaly blue dragonhide')
 	.tertiary(128, 'Clue scroll (hard)');
 
 export default new SimpleMonster({

--- a/src/simulation/monsters/low/a-f/BrutalBlueDragon.ts
+++ b/src/simulation/monsters/low/a-f/BrutalBlueDragon.ts
@@ -52,6 +52,7 @@ const BrutalBlueDragonTable = new LootTable()
 
 	/* Tertiary */
 	.tertiary(20, 'Ensouled dragon head')
+	.tertiary(33, 'Scaly blue dragonhide')
 	.tertiary(128, 'Clue scroll (hard)')
 	.tertiary(750, 'Clue scroll (elite)')
 	.tertiary(10_000, 'Draconic visage');


### PR DESCRIPTION
Now we have the item update, adds the scaly blue dragonhide to the drop tables - https://oldschool.runescape.wiki/w/Scaly_blue_dragonhide

Will do a separate pr to open them 
-   [] I have tested all my changes thoroughly.
