### PR TITLE
Remove tablets from DT2 bosses

### DIFF
--- a/src/simulation/monsters/bosses/DukeSucellus.ts
+++ b/src/simulation/monsters/bosses/DukeSucellus.ts
@@ -61,7 +61,6 @@ class DukeSucellusSingleton extends Monster {
 		...ResourceTable.allItems,
 		...TradeableUniqueTable.allItems,
 		itemID("Awakener's orb"),
-		itemID('Frozen tablet'),
 		itemID('Ice quartz'),
 		itemID('Baron')
 	]);
@@ -75,8 +74,6 @@ class DukeSucellusSingleton extends Monster {
 				loot.add(TradeableUniqueTable.roll());
 			} else if (roll(48)) {
 				loot.add("Awakener's orb");
-			} else if (roll(25)) {
-				loot.add('Frozen tablet');
 			} else if (roll(200)) {
 				loot.add('Ice quartz');
 			} else if (roll(5)) {

--- a/src/simulation/monsters/bosses/TheLeviathan.ts
+++ b/src/simulation/monsters/bosses/TheLeviathan.ts
@@ -59,7 +59,6 @@ class TheLeviathanSingleton extends Monster {
 		...ResourceTable.allItems,
 		...TradeableUniqueTable.allItems,
 		itemID("Awakener's orb"),
-		itemID('Scarred tablet'),
 		itemID('Smoke quartz'),
 		itemID("Lil'viathan")
 	]);
@@ -73,8 +72,6 @@ class TheLeviathanSingleton extends Monster {
 				loot.add(TradeableUniqueTable.roll());
 			} else if (roll(53)) {
 				loot.add("Awakener's orb");
-			} else if (roll(25)) {
-				loot.add('Scarred tablet');
 			} else if (roll(200)) {
 				loot.add('Smoke quartz');
 			} else if (roll(5)) {

--- a/src/simulation/monsters/bosses/TheWhisperer.ts
+++ b/src/simulation/monsters/bosses/TheWhisperer.ts
@@ -60,7 +60,6 @@ class TheWhispererSingleton extends Monster {
 		...ResourceTable.allItems,
 		...TradeableUniqueTable.allItems,
 		itemID("Awakener's orb"),
-		itemID('Sirenic tablet'),
 		itemID('Shadow quartz'),
 		itemID('Wisp')
 	]);
@@ -74,8 +73,6 @@ class TheWhispererSingleton extends Monster {
 				loot.add(TradeableUniqueTable.roll());
 			} else if (roll(34)) {
 				loot.add("Awakener's orb");
-			} else if (roll(25)) {
-				loot.add('Sirenic tablet');
 			} else if (roll(200)) {
 				loot.add('Shadow quartz');
 			} else if (roll(5)) {

--- a/src/simulation/monsters/bosses/Vardorvis.ts
+++ b/src/simulation/monsters/bosses/Vardorvis.ts
@@ -59,7 +59,6 @@ class VardorvisSingleton extends Monster {
 		...ResourceTable.allItems,
 		...TradeableUniqueTable.allItems,
 		itemID("Awakener's orb"),
-		itemID('Strangled tablet'),
 		itemID('Blood quartz'),
 		itemID('Butch')
 	]);
@@ -73,8 +72,6 @@ class VardorvisSingleton extends Monster {
 				loot.add(TradeableUniqueTable.roll());
 			} else if (roll(48)) {
 				loot.add("Awakener's orb");
-			} else if (roll(25)) {
-				loot.add('Strangled tablet');
 			} else if (roll(200)) {
 				loot.add('Blood quartz');
 			} else if (roll(5)) {


### PR DESCRIPTION
### Description:
Works in tandem with the following pr: https://github.com/oldschoolgg/oldschoolbot/pull/5443

### Changes:
Removes tablets from DT2 boss loot tables and allows https://github.com/oldschoolgg/oldschoolbot/pull/5443 to handle the tablets to prevent dupes from taking up loot rolls.

-   [X] I have tested all my changes thoroughly.
