### PR TITLE
Little nightmare fix

### DIFF
--- a/src/simulation/misc/Nightmare.ts
+++ b/src/simulation/misc/Nightmare.ts
@@ -115,15 +115,9 @@ const GearTable = new SimpleTable<string>()
 
 const OrbTable = new SimpleTable<string>().add('Eldritch orb').add('Volatile orb').add('Harmonised orb');
 
-const mvpTertiary = new LootTable()
-	.tertiary(190, 'Clue scroll (elite)')
-	.tertiary(1900, 'Jar of dreams')
-	.tertiary(3800, 'Little nightmare');
+const mvpTertiary = new LootTable().tertiary(190, 'Clue scroll (elite)').tertiary(1900, 'Jar of dreams');
 
-const nonMvpTertiary = new LootTable()
-	.tertiary(200, 'Clue scroll (elite)')
-	.tertiary(2000, 'Jar of dreams')
-	.tertiary(4000, 'Little nightmare');
+const nonMvpTertiary = new LootTable().tertiary(200, 'Clue scroll (elite)').tertiary(2000, 'Jar of dreams');
 
 const phosaniTertiary = new LootTable()
 	.tertiary(35, 'Clue scroll (elite)')
@@ -238,6 +232,13 @@ class NightmareClass {
 			lootResult[teamMember.id].add(
 				options.isPhosani ? phosaniTertiary.roll() : teamMember.mvp ? mvpTertiary.roll() : nonMvpTertiary.roll()
 			);
+			// Pet roll for The Nightmare
+			let petRoll = teamMember.mvp
+				? roll(Math.min(760 * options.team.length, 4000))
+				: roll(Math.min(800 * options.team.length, 4000));
+			if (petRoll) {
+				lootResult[teamMember.id].add('Little Nightmare');
+			}
 		}
 
 		return convertLootBanksToItemBanks(lootResult);

--- a/src/simulation/misc/Nightmare.ts
+++ b/src/simulation/misc/Nightmare.ts
@@ -233,11 +233,15 @@ class NightmareClass {
 				options.isPhosani ? phosaniTertiary.roll() : teamMember.mvp ? mvpTertiary.roll() : nonMvpTertiary.roll()
 			);
 			// Pet roll for The Nightmare
-			let petRoll = teamMember.mvp
-				? roll(Math.min(760 * options.team.length, 4000))
-				: roll(Math.min(800 * options.team.length, 4000));
-			if (petRoll) {
-				lootResult[teamMember.id].add('Little Nightmare');
+			console.log(`options.team.length has: ${options.team.length}`);
+			if (!options.isPhosani) {
+				let petRoll = teamMember.mvp
+					? roll(Math.min(760 * options.team.length, 4000))
+					: roll(Math.min(800 * options.team.length, 4000));
+				console.log(`Team member ${[teamMember.id]} pet roll is: ${petRoll}`);
+				if (petRoll) {
+					lootResult[teamMember.id].add('Little Nightmare');
+				}
 			}
 		}
 


### PR DESCRIPTION
closes: https://github.com/oldschoolgg/oldschoolbot/issues/1023

### Description:
- Fixes Little nightmare drop rates.
"The pet has a 1/800 drop rate in the original encounter, increasing by said amount for every additional player in the room when the fight started; 1/1600 in a duo, 1/2400 in a trio, 1/3200 in a 4-man and 1/4000 in a 5 or higher man encounter. At Phosani's Nightmare, the pet has a flat 1/1400 drop rate." Source: https://oldschool.runescape.wiki/w/Little_nightmare

### Changes:
- Makes Little nightmare drop scale based on party size.
- 5% for MVP
- "Mass nightmare" is capped at user + 3 simulated users but I still added a check to make sure this never goes above 4000.

- [X] I have tested all my changes thoroughly.
