### PR TITLE
Larran's & Brimstone chest fish

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -80,6 +80,7 @@ export const mappedBossNames: [keyof BossRecords, string][] = [
 	['phantomMuspah', 'Phantom Muspah'],
 	['sarachnis', 'Sarachnis'],
 	['scorpia', 'Scorpia'],
+	['scurrius', 'Scurrius'],
 	['skotizo', 'Skotizo'],
 	['spindel', 'Spindel'],
 	['tempoross', 'Tempoross'],

--- a/src/meta/types.ts
+++ b/src/meta/types.ts
@@ -96,6 +96,7 @@ export interface BossRecords {
 	phantomMuspah: MinigameScore;
 	sarachnis: MinigameScore;
 	scorpia: MinigameScore;
+	scurrius: MinigameScore;
 	skotizo: MinigameScore;
 	spindel: MinigameScore;
 	tempoross: MinigameScore;

--- a/src/simulation/openables/BonusOpenables.ts
+++ b/src/simulation/openables/BonusOpenables.ts
@@ -9,7 +9,7 @@ export interface FishDropTable {
 // Uses the skilling success rate formula: https://oldschool.runescape.wiki/w/Skilling_success_rate
 export function chanceOfFish(fishLvl: number, low: number, high: number) {
 	const num1: number = (low * (99 - fishLvl)) / 98;
-	const num2: number = (high.valueOf() * (fishLvl - 1)) / 98;
+	const num2: number = (high * (fishLvl - 1)) / 98;
 
 	const chanceOfSuccess = (num1 + num2 + 1) / 256;
 

--- a/src/simulation/openables/BonusOpenables.ts
+++ b/src/simulation/openables/BonusOpenables.ts
@@ -1,165 +1,173 @@
-import { SkillsEnum } from './../../constants';
-
-export interface BonusOpenables {
+export interface FishDropTable {
 	item: string;
-	qty: number | [number, number];
-	weight: number;
-	skill: SkillsEnum;
-	req: number | [number, number];
+	qty: [number, number];
+	low: number;
+	high: number;
+	req: number;
 }
 
-export const BrimstoneChestBonus: BonusOpenables[] = [
+// Uses the skilling success rate formula: https://oldschool.runescape.wiki/w/Skilling_success_rate
+export function chanceOfFish(fishLvl: number, low: number, high: number) {
+	const num1: number = (low * (99 - fishLvl)) / 98;
+	const num2: number = (high.valueOf() * (fishLvl - 1)) / 98;
+
+	const chanceOfSuccess = (num1 + num2 + 1) / 256;
+
+	return chanceOfSuccess * 100;
+}
+
+export const BrimstoneChestFish: FishDropTable[] = [
 	{
-		item: 'Raw tuna',
-		qty: [100, 350],
-		weight: 3,
-		skill: SkillsEnum.Fishing,
-		req: [1, 39]
-	},
-	{
-		item: 'Raw lobster',
-		qty: [100, 350],
-		weight: 3,
-		skill: SkillsEnum.Fishing,
-		req: [40, 59]
-	},
-	{
-		item: 'Raw swordfish',
-		qty: [100, 300],
-		weight: 3,
-		skill: SkillsEnum.Fishing,
-		req: [50, 61]
-	},
-	{
-		item: 'Raw monkfish',
-		qty: [100, 300],
-		weight: 3,
-		skill: SkillsEnum.Fishing,
-		req: [62, 75]
-	},
-	{
-		item: 'Raw shark',
-		qty: [100, 250],
-		weight: 3,
-		skill: SkillsEnum.Fishing,
-		req: [76, 78]
+		item: 'Raw manta ray',
+		qty: [80, 160],
+		low: -10,
+		high: 20,
+		req: 31
 	},
 	{
 		item: 'Raw sea turtle',
 		qty: [80, 200],
-		weight: 3,
-		skill: SkillsEnum.Fishing,
-		req: [79, 80]
-	},
-	{
-		item: 'Raw manta ray',
-		qty: [80, 160],
-		weight: 3,
-		skill: SkillsEnum.Fishing,
-		req: [81, 99]
-	}
-];
-
-export const LarransSmallChestBonus: BonusOpenables[] = [
-	{
-		item: 'Raw tuna',
-		qty: 204,
-		weight: 3,
-		skill: SkillsEnum.Fishing,
-		req: [1, 39]
-	},
-	{
-		item: 'Raw lobster',
-		qty: 214,
-		weight: 3,
-		skill: SkillsEnum.Fishing,
-		req: [40, 49]
-	},
-	{
-		item: 'Raw swordfish',
-		qty: 224,
-		weight: 3,
-		skill: SkillsEnum.Fishing,
-		req: [50, 61]
-	},
-	{
-		item: 'Raw monkfish',
-		qty: 234,
-		weight: 3,
-		skill: SkillsEnum.Fishing,
-		req: [62, 75]
+		low: -10,
+		high: 50,
+		req: 17
 	},
 	{
 		item: 'Raw shark',
-		qty: 126,
-		weight: 3,
-		skill: SkillsEnum.Fishing,
-		req: [76, 78]
+		qty: [100, 250],
+		low: -60,
+		high: 140,
+		req: 27
+	},
+	{
+		item: 'Raw monkfish',
+		qty: [100, 300],
+		low: 0,
+		high: 170,
+		req: 1
+	},
+	{
+		item: 'Raw swordfish',
+		qty: [100, 300],
+		low: 30,
+		high: 200,
+		req: 1
+	},
+	{
+		item: 'Raw lobster',
+		qty: [100, 350],
+		low: 70,
+		high: 270,
+		req: 1
+	},
+	{
+		item: 'Raw tuna',
+		qty: [100, 350],
+		low: 225,
+		high: 324,
+		req: 1
+	}
+];
+
+export const LarransSmallChestFish: FishDropTable[] = [
+	{
+		item: 'Raw manta ray',
+		qty: [81, 177],
+		low: -10,
+		high: 20,
+		req: 31
 	},
 	{
 		item: 'Raw sea turtle',
-		qty: 136,
-		weight: 3,
-		skill: SkillsEnum.Fishing,
-		req: [79, 80]
-	},
-	{
-		item: 'Raw manta ray',
-		qty: 116,
-		weight: 3,
-		skill: SkillsEnum.Fishing,
-		req: 81
-	}
-];
-
-export const LarransBigChestBonus: BonusOpenables[] = [
-	{
-		item: 'Raw tuna',
-		qty: [150, 520],
-		weight: 3,
-		skill: SkillsEnum.Fishing,
-		req: [1, 39]
-	},
-	{
-		item: 'Raw lobster',
-		qty: [150, 525],
-		weight: 3,
-		skill: SkillsEnum.Fishing,
-		req: [40, 49]
-	},
-	{
-		item: 'Raw swordfish',
-		qty: [150, 450],
-		weight: 3,
-		skill: SkillsEnum.Fishing,
-		req: [50, 61]
-	},
-	{
-		item: 'Raw monkfish',
-		qty: [150, 450],
-		weight: 3,
-		skill: SkillsEnum.Fishing,
-		req: [62, 75]
+		qty: [81, 177],
+		low: -10,
+		high: 50,
+		req: 17
 	},
 	{
 		item: 'Raw shark',
-		qty: [150, 375],
-		weight: 3,
-		skill: SkillsEnum.Fishing,
-		req: [76, 78]
+		qty: [126, 250],
+		low: -60,
+		high: 140,
+		req: 27
+	},
+	{
+		item: 'Raw monkfish',
+		qty: [162, 297],
+		low: 0,
+		high: 170,
+		req: 1
+	},
+	{
+		item: 'Raw swordfish',
+		qty: [113, 264],
+		low: 30,
+		high: 200,
+		req: 1
+	},
+	{
+		item: 'Raw lobster',
+		qty: [163, 342],
+		low: 70,
+		high: 270,
+		req: 1
+	},
+	{
+		item: 'Raw tuna',
+		qty: [112, 307],
+		low: 225,
+		high: 324,
+		req: 1
+	}
+];
+
+export const LarransBigChestFish: FishDropTable[] = [
+	{
+		item: 'Raw manta ray',
+		qty: [120, 240],
+		low: -10,
+		high: 20,
+		req: 31
 	},
 	{
 		item: 'Raw sea turtle',
 		qty: [120, 300],
-		weight: 3,
-		skill: SkillsEnum.Fishing,
-		req: [79, 80]
+		low: -10,
+		high: 50,
+		req: 17
 	},
 	{
-		item: 'Raw manta ray',
-		qty: [125, 235],
-		weight: 3,
-		skill: SkillsEnum.Fishing,
-		req: 81
+		item: 'Raw shark',
+		qty: [150, 375],
+		low: -60,
+		high: 140,
+		req: 27
+	},
+	{
+		item: 'Raw monkfish',
+		qty: [150, 450],
+		low: 0,
+		high: 170,
+		req: 1
+	},
+	{
+		item: 'Raw swordfish',
+		qty: [150, 450],
+		low: 30,
+		high: 200,
+		req: 1
+	},
+	{
+		item: 'Raw lobster',
+		qty: [150, 525],
+		low: 70,
+		high: 270,
+		req: 1
+	},
+	{
+		item: 'Raw tuna',
+		qty: [150, 525],
+		low: 225,
+		high: 324,
+		req: 1
 	}
 ];


### PR DESCRIPTION
### Description:
Updates the code for Larran's and Brimstone chest to properly calculate and give fish based on the users fishing level.
- "If one lands the 1/20 chance to hit the fish drop table, sequential rolls are made until one succeeds, starting with raw manta rays and ending with raw lobsters in case all rolls fail." - osrs wiki Fish drop table


### Changes:
- Update Larran's Big and small chest
- Update Brimstone chest 
- Update FishTable (formerly BonusOpenables) with proper quantities, remove skill and weight.
- Add chanceOfFish function that uses skilling success rate formula from ingame.
- Rework the code to implement the in-game Fish drop table.
- Add scurrius to fix failing tests
### Other checks:
- [X] I have tested all my changes thoroughly.
- Supports: https://github.com/oldschoolgg/oldschoolbot/pull/5426
- Works in tandem with: https://github.com/oldschoolgg/oldschoolbot/pull/5691