### PR TITLE
Mossy key fixes

### DIFF
--- a/src/meta/types.ts
+++ b/src/meta/types.ts
@@ -361,6 +361,7 @@ export interface BankItem {
 
 export interface LootTableMoreOptions {
 	multiply?: boolean;
+	freeze?: boolean;
 }
 
 export interface LootTableItem {

--- a/src/simulation/monsters/bosses/Bryophyta.ts
+++ b/src/simulation/monsters/bosses/Bryophyta.ts
@@ -54,7 +54,7 @@ const BryophytaTable = new LootTable()
 	.add("Bryophyta's essence", 1, 1)
 
 	/* Tertiary */
-	.tertiary(16, "Mossy key")
+	.tertiary(16, "Mossy key", 1, { freeze: true })
 	.tertiary(400, "Long bone")
 	.tertiary(5000, "Giant champion scroll")
 	.tertiary(5013, "Curved bone");

--- a/src/simulation/monsters/low/g-m/MossGiant.ts
+++ b/src/simulation/monsters/low/g-m/MossGiant.ts
@@ -47,10 +47,10 @@ const MossGiantTable = new LootTable()
 	/* Gem drop table */
 	.add(GemTable, 1, 4)
 
-	/* Tertiary, Averaged mossy key */
+	/* Tertiary */
 	.tertiary(24, "Ensouled giant head")
 	.tertiary(45, "Clue scroll (beginner)")
-	.tertiary(55, "Mossy key")
+	.tertiary(150, "Mossy key")
 	.tertiary(400, "Long bone")
 	.tertiary(5000, "Giant champion scroll")
 	.tertiary(5013, "Curved bone");

--- a/src/structures/LootTable.ts
+++ b/src/structures/LootTable.ts
@@ -184,6 +184,7 @@ export default class LootTable {
 		const effectiveTertiaryItems = options?.tertiaryItemPercentageChanges
 			? this.tertiaryItems.map((i) => {
 					if (typeof i.item !== "number") return i;
+					if(i.options?.freeze === true) return i;
 					const change = options.tertiaryItemPercentageChanges?.get(Items.get(i.item)!.name);
 					if (!change) return i;
 					return {

--- a/src/structures/LootTable.ts
+++ b/src/structures/LootTable.ts
@@ -184,7 +184,7 @@ export default class LootTable {
 		const effectiveTertiaryItems = options?.tertiaryItemPercentageChanges
 			? this.tertiaryItems.map((i) => {
 					if (typeof i.item !== "number") return i;
-					if(i.options?.freeze === true) return i;
+					if (i.options?.freeze === true) return i;
 					const change = options.tertiaryItemPercentageChanges?.get(Items.get(i.item)!.name);
 					if (!change) return i;
 					return {


### PR DESCRIPTION
### Description:
- Update mossy key & add a new option to .tertiary()
### Changes:
- Remove the averaged mossy key rate since https://github.com/oldschoolgg/oldschoolbot/pull/5426 will handle it properly.
- Add `freeze?: boolean;` to LootTableMoreOptions. This will prevent unintentional items from having their drop chance manipulated such as being on a moss giant task (which increases mossy key drop rate by 66.67% for moss giants) and killing bryophyta which shouldn't have it's mossy key drop chance altered regardless of slayer task.
### Other checks:
- [X] I have tested all my changes thoroughly.

