### PR TITLE
Remove clue step items & show deleted + added items

### DIFF
--- a/scripts/prepare.ts
+++ b/scripts/prepare.ts
@@ -1,5 +1,26 @@
 import minifyDist from './minifyDist';
 import prepareItems from './prepareItems';
+// @ts-ignore asif
+import _items from '../src/data/items/item_data.json';
 
 minifyDist();
-prepareItems();
+const previousItems: string[] = [];
+for (const key of Object.keys(_items)) {
+	previousItems.push(key);
+}
+
+const newItems: string[] = [];
+const deletedItems: string[] = [];
+prepareItems().then(newItemMap => {
+	for (const key of Object.keys(newItemMap))
+	{
+		if (!previousItems.includes(key)) {
+			newItems.push(key);
+		}
+	}
+	for (const key of previousItems) {
+		if (!newItemMap[key]) deletedItems.push(key);
+	}
+	console.log(`Deleted items: ${deletedItems}`);
+	console.log(`New items: ${newItems}`);
+});

--- a/scripts/prepare.ts
+++ b/scripts/prepare.ts
@@ -1,26 +1,5 @@
 import minifyDist from './minifyDist';
 import prepareItems from './prepareItems';
-// @ts-ignore asif
-import _items from '../src/data/items/item_data.json';
 
 minifyDist();
-const previousItems: string[] = [];
-for (const key of Object.keys(_items)) {
-	previousItems.push(key);
-}
-
-const newItems: string[] = [];
-const deletedItems: string[] = [];
-prepareItems().then(newItemMap => {
-	for (const key of Object.keys(newItemMap))
-	{
-		if (!previousItems.includes(key)) {
-			newItems.push(key);
-		}
-	}
-	for (const key of previousItems) {
-		if (!newItemMap[key]) deletedItems.push(key);
-	}
-	console.log(`Deleted items: ${deletedItems}`);
-	console.log(`New items: ${newItems}`);
-});
+prepareItems();

--- a/scripts/prepareItems.ts
+++ b/scripts/prepareItems.ts
@@ -4,7 +4,7 @@ import { readFileSync, writeFileSync } from 'fs';
 import fetch from 'node-fetch';
 
 import { EquipmentSlot, Item } from '../dist/meta/types';
-import Items, { DO_NOT_REMOVE, USELESS_ITEMS } from '../dist/structures/Items';
+import Items, { CLUE_SCROLLS, CLUE_SCROLL_NAMES, USELESS_ITEMS } from '../dist/structures/Items';
 import { itemID } from '../dist/util';
 import { itemChanges } from './manualItemChanges';
 
@@ -34,9 +34,10 @@ interface RawItemCollection {
 const clueStepRegex = /^Clue scroll \((beginner|easy|medium|hard|elite|master)\) - .*$/;
 
 function itemShouldntBeAdded(item: any) {
-	if (DO_NOT_REMOVE.includes(item.id)) return false;
+	if (CLUE_SCROLLS.includes(item.id)) return false;
 
 	return (
+		CLUE_SCROLL_NAMES.includes(item.name) && !CLUE_SCROLLS.includes(item.id) ||
 		USELESS_ITEMS.includes(item.id) ||
 		item.duplicate === true ||
 		item.noted ||

--- a/scripts/prepareItems.ts
+++ b/scripts/prepareItems.ts
@@ -338,6 +338,8 @@ export default async function prepareItems(): Promise<void> {
 			if (previousItem.price < item.price / 20 && previousItem.price !== 0) dontChange = true;
 			// Prevent weird bug with expensive items: (An item with 2b val on GE had high = 1 & low = 100k)
 			if (item.price < previousItem.price / 10) dontChange = true;
+			// If price differs by 10000x just don't change it.
+			if (price && price.high / 10000 > price.low) dontChange = true;
 		}
 
 		if (dontChange) {

--- a/scripts/prepareItems.ts
+++ b/scripts/prepareItems.ts
@@ -446,7 +446,7 @@ export default async function prepareItems(): Promise<void> {
 
 	const totalQtySql = `SELECT id, SUM(kv.value::int) AS total_quantity
 	FROM users, jsonb_each_text(bank::jsonb) AS kv(itemID, value)
-	WHERE itemID::int = ANY(ARRAY[${deletedItems.join(',')}]::int[])
+	WHERE itemID::int = ANY(ARRAY[${deletedItems.map(i => i.id).join(',')}]::int[])
 	GROUP BY id`;
 	messages.push(`------------------- Get Total Qty of Deleted Items----------------\n${totalQtySql}\n`);
 

--- a/scripts/prepareItems.ts
+++ b/scripts/prepareItems.ts
@@ -234,7 +234,7 @@ const itemsToIgnorePrices = [
 
 const keysToWarnIfRemovedOrAdded: (keyof Item)[] = ['equipable', 'equipment', 'weapon'];
 
-export default async function prepareItems() {
+export default async function prepareItems(): Promise<void> {
 	const messages: string[] = [];
 	const allItemsRaw: RawItemCollection = await fetch(
 		'https://raw.githubusercontent.com/0xNeffarion/osrsreboxed-db/master/docs/items-complete.json'
@@ -454,6 +454,4 @@ FROM users;
 	writeFileSync('./updates.txt', messages.join('\n'));
 
 	messages.push('Prepared items.');
-
-	return itemNameMap;
 }

--- a/src/structures/Items.ts
+++ b/src/structures/Items.ts
@@ -19,13 +19,13 @@ export const CLUE_SCROLLS = [
 ];
 
 export const CLUE_SCROLL_NAMES: string[] = [
-	'Clue scroll (beginner)',
-	'Clue scroll (easy)',
-	'Clue scroll (medium)',
-	'Clue scroll (hard)',
-	'Clue scroll (elite)',
-	'Clue scroll (master)'
-]
+	"Clue scroll (beginner)",
+	"Clue scroll (easy)",
+	"Clue scroll (medium)",
+	"Clue scroll (hard)",
+	"Clue scroll (elite)",
+	"Clue scroll (master)",
+];
 
 export const USELESS_ITEMS = [
 	617, 8890, 6964, 2513, 19_492, 11_071, 11_068, 21_284, 24_735, 21_913, 4703, 4561, 2425, 4692, 3741,

--- a/src/structures/Items.ts
+++ b/src/structures/Items.ts
@@ -32,7 +32,7 @@ export const USELESS_ITEMS = [
 	27_794, 27_795, 27_796, 27_797, 27_798, 27_799, 27_800, 27_801,
 
 	// Clue scrolls - Duplicate or individual step clues that don't match filter
-	3550, 2793, 12_113,	10_184, 12_027,
+	3550, 2793, 12_113, 10_184, 12_027,
 
 	// SOTE Quest Clues
 	23_814, 23_815, 23_816, 23_817,

--- a/src/structures/Items.ts
+++ b/src/structures/Items.ts
@@ -13,6 +13,10 @@ export interface ItemCollection {
 	[index: string]: Item;
 }
 
+export const DO_NOT_REMOVE = [
+	// Clue scrolls
+	2677, 2801, 2722, 12_073, 19_835, 23_182,
+];
 export const USELESS_ITEMS = [
 	617, 8890, 6964, 2513, 19_492, 11_071, 11_068, 21_284, 24_735, 21_913, 4703, 4561, 2425, 4692, 3741,
 
@@ -26,6 +30,15 @@ export const USELESS_ITEMS = [
 	// Removed items
 	10_639, 10_641, 10_644, 10_646, 10_647, 10_648, 10_649, 10_651, 10_652, 10_654, 10_657, 10_658, 10_659, 10_661,
 	27_794, 27_795, 27_796, 27_797, 27_798, 27_799, 27_800, 27_801,
+
+	// Clue scroll step that doesn't match regex
+	3550, 2793, 12_113,
+
+	// SOTE Quest Clues
+	23_814, 23_815, 23_816, 23_817,
+
+	// "New" Clue scroll base items with changed IDs. Removed for consistency.
+	10_184, 12_027,
 ];
 
 class Items extends Collection<number, Item> {

--- a/src/structures/Items.ts
+++ b/src/structures/Items.ts
@@ -37,7 +37,7 @@ export const USELESS_ITEMS = [
 	// SOTE Quest Clues
 	23_814, 23_815, 23_816, 23_817,
 
-	// "New" Clue scroll base items with changed IDs. Removed for consistency.
+	// Duplicate or Individual clue-step items that currently don't match the filtering regex:
 	10_184, 12_027,
 ];
 

--- a/src/structures/Items.ts
+++ b/src/structures/Items.ts
@@ -32,7 +32,7 @@ export const USELESS_ITEMS = [
 	27_794, 27_795, 27_796, 27_797, 27_798, 27_799, 27_800, 27_801,
 
 	// Clue scrolls - Duplicate or individual step clues that don't match filter
-	3550, 2793, 12_113, 10_184, 12_027,
+	3550, 3577, 2793, 12_113, 10_184, 12_027,
 
 	// SOTE Quest Clues
 	23_814, 23_815, 23_816, 23_817,

--- a/src/structures/Items.ts
+++ b/src/structures/Items.ts
@@ -13,10 +13,20 @@ export interface ItemCollection {
 	[index: string]: Item;
 }
 
-export const DO_NOT_REMOVE = [
+export const CLUE_SCROLLS = [
 	// Clue scrolls
 	2677, 2801, 2722, 12_073, 19_835, 23_182,
 ];
+
+export const CLUE_SCROLL_NAMES: string[] = [
+	'Clue scroll (beginner)',
+	'Clue scroll (easy)',
+	'Clue scroll (medium)',
+	'Clue scroll (hard)',
+	'Clue scroll (elite)',
+	'Clue scroll (master)'
+]
+
 export const USELESS_ITEMS = [
 	617, 8890, 6964, 2513, 19_492, 11_071, 11_068, 21_284, 24_735, 21_913, 4703, 4561, 2425, 4692, 3741,
 

--- a/src/structures/Items.ts
+++ b/src/structures/Items.ts
@@ -31,14 +31,11 @@ export const USELESS_ITEMS = [
 	10_639, 10_641, 10_644, 10_646, 10_647, 10_648, 10_649, 10_651, 10_652, 10_654, 10_657, 10_658, 10_659, 10_661,
 	27_794, 27_795, 27_796, 27_797, 27_798, 27_799, 27_800, 27_801,
 
-	// Clue scroll step that doesn't match regex
-	3550, 2793, 12_113,
+	// Clue scrolls - Duplicate or individual step clues that don't match filter
+	3550, 2793, 12_113,	10_184, 12_027,
 
 	// SOTE Quest Clues
 	23_814, 23_815, 23_816, 23_817,
-
-	// Duplicate or Individual clue-step items that currently don't match the filtering regex:
-	10_184, 12_027,
 ];
 
 class Items extends Collection<number, Item> {

--- a/test/items.sanity.test.ts
+++ b/test/items.sanity.test.ts
@@ -3,6 +3,20 @@ import { expect, test } from 'vitest';
 import { Items } from '../src';
 
 test('Items Sanity Test', async () => {
+
+	const beginnerClue = Items.get('Clue scroll (beginner)');
+	expect(beginnerClue.id).toEqual(23_182);
+	const easyClue = Items.get('Clue scroll (easy)');
+	expect(easyClue.id).toEqual(2677);
+	const mediumClue = Items.get('Clue scroll (medium)');
+	expect(mediumClue.id).toEqual(2801);
+	const hardClue = Items.get('Clue scroll (hard)');
+	expect(hardClue.id).toEqual(2722);
+	const eliteClue = Items.get('Clue scroll (elite)');
+	expect(eliteClue.id).toEqual(12_073);
+	const masterClue = Items.get('Clue scroll (master)');
+	expect(masterClue.id).toEqual(19_835);
+
 	const item27624 = Items.get(27_624)!;
 	expect(item27624.id).toEqual(27_624);
 	expect(item27624.name).toEqual('Ancient sceptre');

--- a/test/items.sanity.test.ts
+++ b/test/items.sanity.test.ts
@@ -3,20 +3,6 @@ import { expect, test } from 'vitest';
 import { Items } from '../src';
 
 test('Items Sanity Test', async () => {
-
-	const beginnerClue = Items.get('Clue scroll (beginner)');
-	expect(beginnerClue.id).toEqual(23_182);
-	const easyClue = Items.get('Clue scroll (easy)');
-	expect(easyClue.id).toEqual(2677);
-	const mediumClue = Items.get('Clue scroll (medium)');
-	expect(mediumClue.id).toEqual(2801);
-	const hardClue = Items.get('Clue scroll (hard)');
-	expect(hardClue.id).toEqual(2722);
-	const eliteClue = Items.get('Clue scroll (elite)');
-	expect(eliteClue.id).toEqual(12_073);
-	const masterClue = Items.get('Clue scroll (master)');
-	expect(masterClue.id).toEqual(19_835);
-
 	const item27624 = Items.get(27_624)!;
 	expect(item27624.id).toEqual(27_624);
 	expect(item27624.name).toEqual('Ancient sceptre');


### PR DESCRIPTION
### Description:

-   Removes nearly 600 individual clue-step items (All named `Clue scroll (easy/beginner/medium/hard/elite/master)`)


### Changes:

-   Adds regex to filter out the ~600 clue-step items mentioned above.
-   Adds some items to USELESS_ITEMS array that weren't caught by the filter
-   Adds `DO_NOT_REMOVE` variable to prevent removal of critical items.

-   [] I have tested all my changes thoroughly.
