### PR TITLE
add Elite clues to Araxxor

### DIFF
--- a/src/simulation/monsters/bosses/Araxxor.ts
+++ b/src/simulation/monsters/bosses/Araxxor.ts
@@ -15,6 +15,7 @@ const SupplyDrop = new LootTable()
 	.add(new LootTable().add("Wild pie", [2, 3]).add("Shark", [2, 3]));
 
 const AraxxorTable = new LootTable()
+	.tertiary(50, "Clue scroll (elite)")
 	.tertiary(200, "Coagulated venom")
 	.tertiary(150, AraxxorUniqueTable)
 	.tertiary(250, "Araxyte head")


### PR DESCRIPTION
### Description:

- added Elite clues to Araxxor drop table

### Changes:

- added Elite clues to Araxxor drop table

-   [X] I have tested all my changes thoroughly.
closes: https://github.com/oldschoolgg/oldschoolbot/issues/6094