### PR TITLE
Fix customKillLogic

### DIFF
--- a/src/structures/SimpleMonster.ts
+++ b/src/structures/SimpleMonster.ts
@@ -56,9 +56,13 @@ export default class SimpleMonster extends Monster {
 
 		if (!canGetBrimKey && !wildySlayer && !options.inCatacombs && !options.onSlayerTask) {
 			this.table?.roll(quantity, lootTableOptions);
+			if (this.customKillLogic) {
+				for (let i = 0; i < quantity; i++) {
+					this.customKillLogic(options, loot);
+				}
+			}
 			return loot;
 		}
-
 		for (let i = 0; i < quantity; i++) {
 			if (canGetBrimKey) {
 				if (roll(getBrimKeyChanceFromCBLevel(this.data.combatLevel))) {


### PR DESCRIPTION
### Description:
- fix customKillLogic for monsters like revenants. Currentley revenants only roll the unique table on task due to the check at L57.

### Changes:
- add customKillLogic check to the if check at L57

### Checks:
- [ ] I have tested all my changes thoroughly.
- Unable to test if this works due to the recent changes in osjs and not understanding how these files from `yarn dev` work.
